### PR TITLE
Improve systemd service file

### DIFF
--- a/linux/debian/portmaster.service
+++ b/linux/debian/portmaster.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Portmaster Privacy App
+Description=Portmaster by Safing
 Documentation=https://safing.io
-Documentation=https://github.com/safing/portmaster/wiki
+Documentation=https://docs.safing.io
 Before=nss-lookup.target network.target shutdown.target
 After=systemd-networkd.service
 Conflicts=shutdown.target
@@ -34,7 +34,9 @@ ReadWritePaths=/run/xtables.lock
 RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictSUIDSGID=yes
-ProtectHome=yes
+# In future version portmaster will require access to user home
+# directories to verify application permissions.
+ProtectHome=read-only
 ProtectKernelTunables=yes
 ProtectKernelLogs=yes
 ProtectControlGroups=yes

--- a/linux/debian/portmaster.service
+++ b/linux/debian/portmaster.service
@@ -1,10 +1,53 @@
 [Unit]
-Description=Portmaster Application Firewall
+Description=Portmaster Privacy App
+Documentation=https://safing.io
+Documentation=https://github.com/safing/portmaster/wiki
+Before=nss-lookup.target network.target shutdown.target
+After=systemd-networkd.service
+Conflicts=shutdown.target
+Wants=nss-lookup.target
+
+# The Portmaster will conflict with almost all DNS services that
+# that are listening on 53/upd or 53/tcp. Only DNS services that
+# are likely to be running on desktop systems are listed here so
+# systemd can gracefully stop them when portmaster is started.
+# Note that manually starting one of the below services will instruct
+# systemd to request portmaster to stop.
+Conflicts=systemd-resolved.service dnsmasq.service unbound.service nextdns.service
 
 [Service]
-ExecStart=/usr/bin/portmaster-control run core --data=/var/lib/portmaster/
-ExecStopPost=/bin/sh -c "/sbin/iptables -F C17 || /bin/true; /sbin/iptables -t mangle -F C170 || /bin/true; /sbin/iptables -t mangle -F 171 || /bin/true;"
-#shouldn't be required ... for very unclean stops like kill -9
+Type=simple
+Restart=always
+RestartSec=10
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PIDFile=/var/lib/portmaster/core-lock.pid
+Environment=LOGLEVEL=info
+Environment=PORTMASTER_ARGS=
+EnvironmentFile=-/etc/default/portmaster
+ProtectSystem=strict
+ReadWritePaths=/var/lib/portmaster
+# Portmaster calls iptables which requires to set xtables.lock
+ReadWritePaths=/run/xtables.lock
+RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+PrivateDevices=yes
+AmbientCapabilities=cap_chown cap_kill cap_net_admin cap_net_bind_service cap_net_broadcast cap_net_raw cap_sys_module cap_sys_ptrace cap_dac_override
+CapabilityBoundingSet=cap_chown cap_kill cap_net_admin cap_net_bind_service cap_net_broadcast cap_net_raw cap_sys_module cap_sys_ptrace cap_dac_override
+SystemCallArchitectures=native
+SystemCallFilter=@system-service @module
+SystemCallErrorNumber=EPERM
+ExecStart=/var/lib/portmaster/portmaster-start --data /var/lib/portmaster core -- --log $LOGLEVEL $PORTMASTER_ARGS
+ExecStopPost=-/sbin/iptables -F C17
+ExecStopPost=-/sbin/iptables -t mangle -F C170
+ExecStopPost=-/sbin/iptables -t mangle -F 171
 
 [Install]
 WantedBy=multi-user.target

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -9,7 +9,7 @@ build:	portmaster-control
 #	convert logo.png -resize 32x32 portmaster.png
 
 portmaster-control:
-	curl -o portmaster-control https://updates.safing.io/latest/linux_amd64/control/portmaster-control
+	curl -o portmaster-control https://updates.safing.io/latest/linux_amd64/control/portmaster-control\?installer-build
 	# TODO: verify signature
 
 #Don't run strip for go-binaries

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -3,7 +3,7 @@ WINE := $(shell command -v wine 2> /dev/null)
 all: portmaster-uninstaller.exe portmaster-installer.exe
 
 portmaster-control.exe:
-	curl -o portmaster-control.exe https://updates.safing.io/latest/windows_amd64/control/portmaster-control.exe
+	curl -o portmaster-control.exe https://updates.safing.io/latest/windows_amd64/control/portmaster-control.exe\?installer-build
 
 portmaster-uninstaller.exe: portmaster-installer.nsi install_summary.nsh
 	makensis -DUNINSTALLER portmaster-installer.nsi


### PR DESCRIPTION
This PR updates the systemd service to include more protective stanzas.

**Related Issues**
- https://github.com/safing/portmaster/pull/96 is required for this
- https://github.com/safing/portmaster/issues/99 is affected as we have a `Conflicts=` stanza now.
- https://github.com/safing/portmaster-packaging/issues/2 is fixed