### PR TITLE
Migrate to portmaster-start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 *.deb
 /portmaster_*.*
-/linux/portmaster-control
+/linux/portmaster-start
 /linux/debian/files
 /linux/debian/*.log
 /linux/debian/*.substvars
 /linux/debian/*.debhelper
 /linux/debian/portmaster/
-/windows/portmaster-control.exe
+/windows/portmaster-start.exe
 /windows/portmaster-installer.exe
 /windows/portmaster-uninstaller.exe
 /windows/uninstaller_pkg.exe

--- a/linux/README.md
+++ b/linux/README.md
@@ -6,7 +6,7 @@ How to build:
 
 1. install requirements: `apt install debhelper`
 2. `./build.sh`
-  - this will download the latest portmaster-control
+  - this will download the latest portmaster-start
   - results will be in parent dir
 3. copy to dist directory with versioned file name
 

--- a/linux/debian/clean
+++ b/linux/debian/clean
@@ -1,1 +1,1 @@
-portmaster-control
+portmaster-start

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -8,8 +8,8 @@ Homepage: https://safing.io/
 Package: portmaster
 Architecture: amd64
 Pre-Depends: ${misc:Depends}
-Depends: libnetfilter-queue1, libc6, libappindicator-gtk3, ${shlibs:Depends}
-Recommends: gir1.2-harfbuzz-0.0
+Depends: libnetfilter-queue1, libc6, ${shlibs:Depends}
+Recommends: gir1.2-harfbuzz-0.0, libappindicator3-1
 Description: Application Firewall
  The Portmaster enables you to protect your data on your device. You
  are back in charge of your outgoing connections: you choose what data

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -8,7 +8,7 @@ Homepage: https://safing.io/
 Package: portmaster
 Architecture: amd64
 Pre-Depends: ${misc:Depends}
-Depends: libnetfilter-queue1, libc6, ${shlibs:Depends}
+Depends: libnetfilter-queue1, libc6, libappindicator-gtk3, ${shlibs:Depends}
 Recommends: gir1.2-harfbuzz-0.0
 Description: Application Firewall
  The Portmaster enables you to protect your data on your device. You

--- a/linux/debian/portmaster.install
+++ b/linux/debian/portmaster.install
@@ -1,5 +1,5 @@
 portmaster_notifier.desktop /etc/xdg/autostart/
-portmaster-control /usr/bin/
+portmaster-start /var/lib/portmaster
 portmaster.desktop /usr/share/applications/
 portmaster_notifier.desktop /usr/share/applications/
 portmaster.png /usr/share/pixmaps/

--- a/linux/debian/postinst
+++ b/linux/debian/postinst
@@ -2,4 +2,7 @@
 
 . /usr/share/debconf/confmodule #just to make lintian happy and maybe prevent some sort of error ...
 
+/var/lib/portmaster/portmaster-start --data=/var/lib/portmaster update
+rm /usr/bin/portmaster-control || true
+
 #DEBHELPER#

--- a/linux/debian/postinst
+++ b/linux/debian/postinst
@@ -2,7 +2,33 @@
 
 . /usr/share/debconf/confmodule #just to make lintian happy and maybe prevent some sort of error ...
 
-/var/lib/portmaster/portmaster-start --data=/var/lib/portmaster update
-rm /usr/bin/portmaster-control || true
+chmod a+x /var/lib/portmaster/portmaster-start
+
+log() {
+    echo "\e[1mportmaster: \e[0m $@"
+}
+
+print_dl_help() {
+    log ""
+    log "\e[33;1mWARN: $1\e[0m"
+    log "downloading assets can be initiated by starting the Portmaster service or by running:"
+    log "/var/lib/portmaster/portmaster-start --data=/var/lib/portmaster update"
+    log ""
+}
+
+if [ -z "${PM_SKIP_DOWNLOAD}" ]; then
+    log "downloading assets, this may take a while"
+    /var/lib/portmaster/portmaster-start --data=/var/lib/portmaster update || \
+        (
+            print_dl_help "Downloading assets failed!"
+            log "installation successfull"
+        )
+else
+    print_dl_help "skipped downloading assets!"
+fi
+
+# with 0.4.0 portmaster-control has ben renamed to portmaster-start
+# and is not placed into /usr/bin anymore.
+rm /usr/bin/portmaster-control 2> /dev/null || true
 
 #DEBHELPER#

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -11,7 +11,7 @@ build:	portmaster-start
 #	convert logo.png -resize 32x32 portmaster.png
 
 portmaster-start:
-	curl -o portmaster-start $(STARTURL)
+	curl --fail -o portmaster-start $(STARTURL)
 
 #Don't run strip for go-binaries
 override_dh_strip:

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -1,6 +1,8 @@
 #!/usr/bin/make -f
+STARTURL ?= https://updates.safing.io/latest/linux_amd64/control/portmaster-start\?installer-build
+
 # We don't build here, we download the built binaries
-build:	portmaster-control
+build:	portmaster-start
 
 %:
 	dh $@ --with=systemd
@@ -8,9 +10,8 @@ build:	portmaster-control
 #portmaster.png:
 #	convert logo.png -resize 32x32 portmaster.png
 
-portmaster-control:
-	curl -o portmaster-control https://updates.safing.io/latest/linux_amd64/control/portmaster-control\?installer-build
-	# TODO: verify signature
+portmaster-start:
+	curl -o portmaster-start $(STARTURL)
 
 #Don't run strip for go-binaries
 override_dh_strip:

--- a/linux/portmaster.desktop
+++ b/linux/portmaster.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Portmaster
 GenericName=Application Firewall
-Exec=portmaster-control run app --data=/var/lib/portmaster
+Exec=/var/lib/portmaster/portmaster-start app --data=/var/lib/portmaster
 Icon=/usr/share/pixmaps/portmaster.png
 Terminal=false
 Type=Application

--- a/linux/portmaster_notifier.desktop
+++ b/linux/portmaster_notifier.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Portmaster Notifier
 GenericName=Application Firewall Notifier
-Exec=portmaster-control run notifier --data=/var/lib/portmaster
+Exec=/var/lib/portmaster/portmaster-start notifier --data=/var/lib/portmaster
 Icon=/usr/share/pixmaps/portmaster.png
 Terminal=false
 Type=Application

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -1,9 +1,10 @@
 WINE := $(shell command -v wine 2> /dev/null)
+STARTURL ?= https://updates.safing.io/latest/windows_amd64/control/portmaster-start.exe\?installer-build
 
 all: portmaster-uninstaller.exe portmaster-installer.exe
 
-portmaster-control.exe:
-	curl -o portmaster-control.exe https://updates.safing.io/latest/windows_amd64/control/portmaster-control.exe\?installer-build
+portmaster-start.exe:
+	curl -o portmaster-start.exe $(STARTURL)
 
 portmaster-uninstaller.exe: portmaster-installer.nsi install_summary.nsh
 	makensis -DUNINSTALLER portmaster-installer.nsi
@@ -21,7 +22,7 @@ install_summary.nsh:
 	perl -p -e 's/\r?\n/\$$\\r\$$\\n/' install_summary.rtf >> install_summary.nsh
 	echo '"' >> install_summary.nsh
 
-portmaster-installer.exe: portmaster-control.exe portmaster-installer.nsi portmaster-uninstaller.exe install_summary.nsh
+portmaster-installer.exe: portmaster-start.exe portmaster-installer.nsi portmaster-uninstaller.exe install_summary.nsh
 	makensis -DINSTALLER -DPRODUCTION portmaster-installer.nsi #Production enables good compression (takes longer)
 	#TODO: sign
 
@@ -30,4 +31,4 @@ clean:
 	rm -f uninstaller_pkg.exe
 	rm -f portmaster-installer.exe
 	rm -f install_summary.nsh
-	rm -rf portmaster-control.exe
+	rm -rf portmaster-start.exe

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -4,7 +4,7 @@ STARTURL ?= https://updates.safing.io/latest/windows_amd64/control/portmaster-st
 all: portmaster-uninstaller.exe portmaster-installer.exe
 
 portmaster-start.exe:
-	curl -o portmaster-start.exe $(STARTURL)
+	curl --fail -o portmaster-start.exe $(STARTURL)
 
 portmaster-uninstaller.exe: portmaster-installer.nsi install_summary.nsh
 	makensis -DUNINSTALLER portmaster-installer.nsi

--- a/windows/README.md
+++ b/windows/README.md
@@ -3,7 +3,7 @@
 The Windows Installer is built with NSIS.
 
 Here is how:
-1. [Linux] download latest portmaster-control: `make portmaster-control.exe`
+1. [Linux] download latest portmaster-start: `make portmaster-start.exe`
 2. [Linux] build uninstaller: `make portmaster-uninstaller.exe`
 3. [Windows] sign uninstaller: `sign.bat portmaster-uninstaller.exe`
 4. [Linux] build installer (includes the uninstaller): `make portmaster-installer.exe`

--- a/windows/portmaster-installer.nsi
+++ b/windows/portmaster-installer.nsi
@@ -76,7 +76,7 @@ Function .onInit
 	StrCpy $DataPath "$0\Safing\Portmaster"
 	StrCpy $DataPath_parent "$0\Safing"
 FunctionEnd
-
+emc
 Function un.onInit
 	ReadEnvStr $0 PROGRAMDATA
 	StrCpy $DataPath "$0\Safing\Portmaster"
@@ -128,23 +128,25 @@ noupdate:
 	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{7F00FB48-65D5-4BA8-A35B-F194DA7E1A51}\LocalServer32" "" '"$INSTDIR\${ExeName}" notifier-snoretoast'
 
 ; download
+	DetailPrint "Downloading portmaster updates, this may take a while ..."
 	nsExec::ExecToStack '$INSTDIR\${ExeName} update --data=$DataPath'
 	pop $0
 	pop $1
-	DetailPrint $1
+	; DetailPrint $1 ; # would print > BOF from portmaster-start log
 	${If} $0 <> 0
-		MessageBox MB_ICONEXCLAMATION "Failed to download Portmaster assets."
+		MessageBox MB_ICONEXCLAMATION "Failed to download Portmaster updates."
 		SetErrors
 		Abort
 	${EndIf}
 
 ; register Service
+	DetailPrint "Installing Portmaster as a Windows Service ..."
 	nsExec::ExecToStack '$INSTDIR\${ExeName} install core-service --data=$DataPath'
 	pop $0
 	pop $1
 	DetailPrint $1
 	${If} $0 <> 0
-		MessageBox MB_ICONEXCLAMATION "Windows Service registration was unsuccessfull, see details."
+		MessageBox MB_ICONEXCLAMATION "Windows Service registration failed, see details."
 		SetErrors
 		Abort
 	${EndIf}

--- a/windows/portmaster-installer.nsi
+++ b/windows/portmaster-installer.nsi
@@ -26,7 +26,7 @@ SetCompress off
 
 InstallDir "$Programfiles64\Safing\Portmaster"
 !define Parent_InstallDir "$Programfiles64\Safing"
-!define ExeName "portmaster-control.exe"
+!define ExeName "portmaster-start.exe"
 !define LogoName "portmaster.ico"
 !define SnoreToastExe "SnoreToast.exe"
 
@@ -111,9 +111,9 @@ noupdate:
 	
 	SetShellVarContext all
 	CreateDirectory "$SMPROGRAMS\Portmaster"
-	CreateShortcut "$SMPROGRAMS\Portmaster\Portmaster.lnk" "$INSTDIR\${ExeName}" "run app --data=$DataPath" "$INSTDIR\portmaster.ico"
-	CreateShortcut "$SMPROGRAMS\Portmaster\Portmaster Notifier.lnk" "$INSTDIR\${ExeName}" "run notifier --data=$DataPath" "$INSTDIR\portmaster.ico"
-	CreateShortcut "$SMSTARTUP\Portmaster Notifier.lnk" "$INSTDIR\${ExeName}" "run notifier --data=$DataPath" "$INSTDIR\portmaster.ico"
+	CreateShortcut "$SMPROGRAMS\Portmaster\Portmaster.lnk" "$INSTDIR\${ExeName}" "app --data=$DataPath" "$INSTDIR\portmaster.ico"
+	CreateShortcut "$SMPROGRAMS\Portmaster\Portmaster Notifier.lnk" "$INSTDIR\${ExeName}" "notifier --data=$DataPath" "$INSTDIR\portmaster.ico"
+	CreateShortcut "$SMSTARTUP\Portmaster Notifier.lnk" "$INSTDIR\${ExeName}" "notifier --data=$DataPath" "$INSTDIR\portmaster.ico"
 
 ; The GUID can be read out like this: strings snoretoast.exe | grep -E '^\{[[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12}\}$' (maybe additional lines with false-positives)
 	!insertmacro ShortcutSetToastProperties "$SMPROGRAMS\Portmaster\Portmaster.lnk" "{7F00FB48-65D5-4BA8-A35B-F194DA7E1A51}" "io.safing.portmaster"
@@ -125,7 +125,18 @@ noupdate:
 	${EndIf}
 	DetailPrint "Returncode when setting Shortcut: $0 (0: S_OK)"
 
-	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{7F00FB48-65D5-4BA8-A35B-F194DA7E1A51}\LocalServer32" "" '"$INSTDIR\${ExeName}" run notifier-snoretoast'
+	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{7F00FB48-65D5-4BA8-A35B-F194DA7E1A51}\LocalServer32" "" '"$INSTDIR\${ExeName}" notifier-snoretoast'
+
+; download
+	nsExec::ExecToStack '$INSTDIR\${ExeName} update --data=$DataPath'
+	pop $0
+	pop $1
+	DetailPrint $1
+	${If} $0 <> 0
+		MessageBox MB_ICONEXCLAMATION "Failed to download Portmaster assets."
+		SetErrors
+		Abort
+	${EndIf}
 
 ; register Service
 	nsExec::ExecToStack '$INSTDIR\${ExeName} install core-service --data=$DataPath'
@@ -133,7 +144,7 @@ noupdate:
 	pop $1
 	DetailPrint $1
 	${If} $0 <> 0
-		MessageBox MB_ICONEXCLAMATION "registering Service was unsuccessfull, see Details"
+		MessageBox MB_ICONEXCLAMATION "Windows Service registration was unsuccessfull, see details."
 		SetErrors
 		Abort
 	${EndIf}
@@ -155,7 +166,7 @@ noupdate:
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Portmaster" \
 		"Publisher" "Safing ICS Technologies GmbH"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Portmaster" \
-		"HelpLink" "https://discourse.safing.community/"
+		"HelpLink" "https://reddit.com/r/safing/"
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Portmaster" \
 		"NoRepair" 1
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Portmaster" \


### PR DESCRIPTION
This PR migrates to portmaster-start. It should only be merged once https://github.com/safing/portmaster/pull/96 has been merged and portmaster-start has been released to updates.safing.io.
