### PR TITLE
Make curl return an error on HTTP error codes

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -9,7 +9,7 @@ build:	portmaster-control
 #	convert logo.png -resize 32x32 portmaster.png
 
 portmaster-control:
-	curl -o portmaster-control https://updates.safing.io/latest/linux_amd64/control/portmaster-control
+	curl -o portmaster-control --fail https://updates.safing.io/latest/linux_amd64/control/portmaster-control
 	# TODO: verify signature
 
 #Don't run strip for go-binaries

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -3,7 +3,7 @@ WINE := $(shell command -v wine 2> /dev/null)
 all: portmaster-uninstaller.exe portmaster-installer.exe
 
 portmaster-control.exe:
-	curl -o portmaster-control.exe https://updates.safing.io/latest/windows_amd64/control/portmaster-control.exe
+	curl -o portmaster-control.exe --fail https://updates.safing.io/latest/windows_amd64/control/portmaster-control.exe
 
 portmaster-uninstaller.exe: portmaster-installer.nsi install_summary.nsh
 	makensis -DUNINSTALLER portmaster-installer.nsi


### PR DESCRIPTION
Previously build-deb and build-nsis workflows wouldn't fail in case the requested resource from updates.safing.io does not exist. Now they fail.