### PR TITLE
Set User-Agent=GitHub for CI builds

### DIFF
--- a/.github/workflows/linux-deb.yml
+++ b/.github/workflows/linux-deb.yml
@@ -51,7 +51,7 @@ jobs:
         run: apt install -y --no-install-recommends libnetfilter-queue1
 
       - name: Install Portmaster
-        run: bash -c "set -e ; dpkg -i ./portmaster.deb/*.deb"
+        run: bash -c "set -e ; PMSTART_UPDATE_AGENT=GitHub dpkg -i ./portmaster.deb/*.deb"
 
       - name: Verify executable portmaster-start
         run: bash -c "set -e ; [[ -x /var/lib/portmaster/portmaster-start ]] || exit 1"

--- a/linux/debian/postinst
+++ b/linux/debian/postinst
@@ -18,7 +18,8 @@ print_dl_help() {
 
 if [ -z "${PM_SKIP_DOWNLOAD}" ]; then
     log "downloading assets, this may take a while"
-    /var/lib/portmaster/portmaster-start --data=/var/lib/portmaster update || \
+    PMSTART_UPDATE_AGENT=${PMSTART_UPDATE_AGENT:=Start}
+    /var/lib/portmaster/portmaster-start --data=/var/lib/portmaster update --update-agent ${PMSTART_UPDATE_AGENT}  || \
         (
             print_dl_help "Downloading assets failed!"
             log "installation successfull"

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -11,7 +11,7 @@ build:	portmaster-start
 #	convert logo.png -resize 32x32 portmaster.png
 
 portmaster-start:
-	curl --fail -o portmaster-start $(STARTURL)
+	curl --fail --user-agent GitHub -o portmaster-start $(STARTURL)
 
 #Don't run strip for go-binaries
 override_dh_strip:

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -4,7 +4,7 @@ STARTURL ?= https://updates.safing.io/latest/windows_amd64/start/portmaster-star
 all: portmaster-uninstaller.exe portmaster-installer.exe
 
 portmaster-start.exe:
-	curl --fail -o portmaster-start.exe $(STARTURL)
+	curl --fail --user-agent GitHub -o portmaster-start.exe $(STARTURL)
 
 portmaster-uninstaller.exe: portmaster-installer.nsi install_summary.nsh
 	makensis -DUNINSTALLER portmaster-installer.nsi


### PR DESCRIPTION
Requires a portmaster-start binary with --update-agent support to be released