### PR TITLE
Add ArchLinux PKGBUILD

### DIFF
--- a/.github/actions/build-arch/Dockerfile
+++ b/.github/actions/build-arch/Dockerfile
@@ -1,0 +1,6 @@
+FROM greyltc/archlinux-aur:latest
+
+RUN pacman -Sy && pacman -S --needed --noconfirm imagemagick libnetfilter_queue xz webkit2gtk
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build-arch/action.yml
+++ b/.github/actions/build-arch/action.yml
@@ -1,0 +1,13 @@
+name: 'Build ArchLinux AUR package'
+description: 'Build a ArchLinux AUR package'
+outputs:
+  filename:
+    description: 'Name of the built `.pkg.tar.xz` file'
+
+runs:
+  using: docker
+  image: Dockerfile
+
+branding:
+  icon: package
+  color: gray-dark

--- a/.github/actions/build-arch/entrypoint.sh
+++ b/.github/actions/build-arch/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+cd linux
+chown -R docker:docker .
+
+# Reset PKGEXT to it's default (it's different in the build-container)
+PKGEXT=".pkg.tar.xz" su docker -c makepkg
+
+ls -lah
+
+pkgname=$(ls *.pkg.tar*)
+mv $pkgname ../$pkgname
+echo ::set-output name=filename::$pkgname

--- a/.github/workflows/linux-arch.yml
+++ b/.github/workflows/linux-arch.yml
@@ -1,0 +1,22 @@
+name: Arch Linux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-arch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: ./.github/actions/build-arch
+        id: build
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.build.outputs.filename }}
+          path: ${{ steps.build.outputs.filename }}

--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -1,0 +1,4 @@
+/src
+/portmaster.service
+/pkg
+/portmaster-*-x86_64.pkg.tar.xz

--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Patrick Pacher <patrick@safing.io>
+pkgname=portmaster
+pkgver=0.4.1
+pkgrel=1
+pkgdesc='Application Firewall: Block Mass Surveillance - Love Freedom'
+arch=('x86_64')
+license=('AGPL3')
+depends=('libnetfilter_queue' 'webkit2gtk')
+makedepends=('imagemagick') # for convert
+optdepends=('libappindicator-gtk3: for systray indicator')
+options=('!strip')
+#changelog=
+source=("portmaster-start::https://updates.safing.io/linux_amd64/start/portmaster-start_v${pkgver//./-}"
+		'./portmaster.desktop'
+		'./portmaster_notifier.desktop'
+		'./portmaster_logo.png'
+		"portmaster.service::file://$(pwd)/debian/portmaster.service")
+noextract=('portmaster-start')
+md5sums=('0b529627ba8ba7c8331538c85e464d00'
+  '19864fff9d542c427acb727636ac5390'
+  '51c3e38b7db3add32e462819c6d1f4e5'
+  'bd72c66922a3cdb089fa80daba1772f8'
+  'd4425dab7263b8c64ae0c460e03dc8c8')
+
+prepare() {
+	for res in 16 32 48 96 128 ; do
+		local iconpath=${pkgname}-${pkgver}/icons/${res}x${res}/apps
+		mkdir -p ${iconpath} ; 
+		convert ./portmaster_logo.png -resize ${res}x${res} ${iconpath}/portmaster.png ; 
+	done
+}
+
+build() {
+	mkdir -p ${pkgname}-${pkgver}/data
+	chmod a+x ${srcdir}/portmaster-start
+	${srcdir}/portmaster-start --data ${pkgname}-${pkgver}/data update
+}
+
+package() {
+	mkdir -p ${pkgdir}/var/lib/portmaster
+	mkdir -p ${pkgdir}/usr/lib/systemd/system
+	mkdir -p ${pkgdir}/usr/share/icons/hicolor/
+	cp ${srcdir}/portmaster.service ${pkgdir}/usr/lib/systemd/system/portmaster.service
+	cp ${srcdir}/portmaster-start ${pkgdir}/var/lib/portmaster/
+	cp -r ${srcdir}/${pkgname}-${pkgver}/data/* ${pkgdir}/var/lib/portmaster/
+	cp -r ${srcdir}/${pkgname}-${pkgver}/icons/* ${pkgdir}/usr/share/icons/hicolor/
+}

--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -40,8 +40,11 @@ package() {
 	mkdir -p ${pkgdir}/var/lib/portmaster
 	mkdir -p ${pkgdir}/usr/lib/systemd/system
 	mkdir -p ${pkgdir}/usr/share/icons/hicolor/
+	mkdir -p ${pkgdir}/usr/share/applications/
 	cp ${srcdir}/portmaster.service ${pkgdir}/usr/lib/systemd/system/portmaster.service
 	cp ${srcdir}/portmaster-start ${pkgdir}/var/lib/portmaster/
 	cp -r ${srcdir}/${pkgname}-${pkgver}/data/* ${pkgdir}/var/lib/portmaster/
 	cp -r ${srcdir}/${pkgname}-${pkgver}/icons/* ${pkgdir}/usr/share/icons/hicolor/
+	cp ${srcdir}/portmaster.desktop ${pkgdir}/usr/share/applications/
+	cp ${srcdir}/portmaster_notifier.desktop ${pkgdir}/usr/share/applications/
 }


### PR DESCRIPTION
This PR adds a PKGBUILD file to build ArchLinux packages using `makepkg`. It partly fixes #18  but publishing the PKGBUILD to AUR is not yet planned (let's get some feedback on the PKGBUILD first).

Though, we should be able to distribute the `.pkg.tar.xz` file from the ArchLinux build action [build-arch (prev run)](https://github.com/safing/portmaster-packaging/actions/runs/188576433) via the update server.

In contrast to the .deb installer the archlinux package does NOT download the portmaster modules (`portmaster-start update`) during installation time, it rather downloads then in the PKGBUILD build() phase. So installing the built `.pkg.tar.xz` package file contains the latest (at-time-of-build) portmaster-core, the notifier and the UI bundles. 

This is prefered here as most ArchLinux users (including myself), don't trust pre-built packages from outside the official repos and run `makepkg` themself after inspecting the PKGBUILD. This will download the latest portmaster binaries anyway.