### PR TITLE
Arch post_remove() and version bumps

### DIFF
--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -2,3 +2,4 @@
 /portmaster.service
 /pkg
 /portmaster-*-x86_64.pkg.tar.xz
+/icons

--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Patrick Pacher <patrick@safing.io>
 pkgname=portmaster
-pkgver=0.4.1
+pkgver=0.4.2
 pkgrel=1
 pkgdesc='Application Firewall: Block Mass Surveillance - Love Freedom'
 arch=('x86_64')
 license=('AGPL3')
+install=arch.install
 depends=('libnetfilter_queue' 'webkit2gtk')
 makedepends=('imagemagick') # for convert
 optdepends=('libappindicator-gtk3: for systray indicator')
@@ -16,7 +17,7 @@ source=("portmaster-start::https://updates.safing.io/linux_amd64/start/portmaste
 		'./portmaster_logo.png'
 		"portmaster.service::file://$(pwd)/debian/portmaster.service")
 noextract=('portmaster-start')
-md5sums=('0b529627ba8ba7c8331538c85e464d00'
+md5sums=('944cf556ca4b198834304f397ca978c1'
   '19864fff9d542c427acb727636ac5390'
   'cebfc4aa5f12a1da9b9ebf70f26f0d6f'
   'bd72c66922a3cdb089fa80daba1772f8'

--- a/linux/arch.install
+++ b/linux/arch.install
@@ -1,0 +1,4 @@
+post_remove() {
+    echo "Removing portmaster modules"
+    rm -f var/lib/portmaster/updates
+}

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+portmaster (0.4.2.0) buster; urgency=low
+
+  * Update to portmaster-start 0.4.2
+
+ -- Safing <noc@safing.io> Wed, 05 Aug 2020 09:30:01 +200
+
 portmaster (0.4.1.3) buster; urgency=low
 
   * Update to compat 11.


### PR DESCRIPTION
**ArchLinux**:

 - Add `post_remove()` to delete `/var/lib/portmaster/updates`
 - Bump to version `0.4.2`

**Debian**

 -  Bump to version `0.4.2`
