### PR TITLE
Update hashes for makepkg integrity check

### DIFF
--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -17,11 +17,11 @@ source=("portmaster-start::https://updates.safing.io/linux_amd64/start/portmaste
 		'./portmaster_logo.png'
 		"portmaster.service::file://$(pwd)/debian/portmaster.service")
 noextract=('portmaster-start')
-md5sums=('607a7d6adbd9bc95ff2e87f4754f6326'
-  '19864fff9d542c427acb727636ac5390'
-  'cebfc4aa5f12a1da9b9ebf70f26f0d6f'
-  'c5484dd4e42606f8141abdc4e04d5d61'
-  'a568e92f6a6f219ded28d8bfd1d6e1f5')
+md5sums=('e267b0b2913fc84babcd805264b2d0f7'
+         '19864fff9d542c427acb727636ac5390'
+         'cebfc4aa5f12a1da9b9ebf70f26f0d6f'
+         'c5484dd4e42606f8141abdc4e04d5d61'
+         'a568e92f6a6f219ded28d8bfd1d6e1f5')
 
 prepare() {
 	for res in 16 32 48 96 128 ; do


### PR DESCRIPTION
Building on Manjaro with 'makepkg -i' did not pass the integrity checks.
Regenerated the hashes.