### PR TITLE
Some minor PKGBUILD tweaks 

### DIFF
--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -12,10 +12,10 @@ optdepends=('libappindicator-gtk3: for systray indicator')
 options=('!strip')
 #changelog=
 source=("portmaster-start::https://updates.safing.io/linux_amd64/start/portmaster-start_v${pkgver//./-}"
-		'./portmaster.desktop'
-		'./portmaster_notifier.desktop'
-		'./portmaster_logo.png'
-		"portmaster.service::file://$(pwd)/debian/portmaster.service")
+		'portmaster.desktop'
+		'portmaster_notifier.desktop'
+		'portmaster_logo.png'
+		"debian/portmaster.service")
 noextract=('portmaster-start')
 md5sums=('e267b0b2913fc84babcd805264b2d0f7'
          '19864fff9d542c427acb727636ac5390'

--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -38,14 +38,13 @@ build() {
 }
 
 package() {
+	install -Dm 644 "${srcdir}/portmaster.service" "${pkgdir}/usr/lib/systemd/system/portmaster.service"
+	install -Dm 755 "${srcdir}/portmaster-start" "${pkgdir}/var/lib/portmaster/portmaster-start"
+	install -Dm 644 "${srcdir}/portmaster.desktop" "${pkgdir}/usr/share/applications/portmaster.desktop"
+	install -Dm 644 "${srcdir}/portmaster_notifier.desktop" "${pkgdir}/usr/share/applications/portmaster_notifier.desktop"
+
 	install -dm 755 "${pkgdir}/var/lib/portmaster/"
-	install -dm 755 "${pkgdir}/usr/lib/systemd/system/"
 	install -dm 755 "${pkgdir}/usr/share/icons/hicolor/"
-	install -dm 755 "${pkgdir}/usr/share/applications/"
-	cp "${srcdir}/portmaster.service" "${pkgdir}/usr/lib/systemd/system/portmaster.service"
-	cp "${srcdir}/portmaster-start" "${pkgdir}/var/lib/portmaster/"
 	cp -r "${srcdir}/${pkgname}-${pkgver}/data/"* "${pkgdir}/var/lib/portmaster/"
 	cp -r "${srcdir}/${pkgname}-${pkgver}/icons/"* "${pkgdir}/usr/share/icons/hicolor/"
-	cp "${srcdir}/portmaster.desktop" "${pkgdir}/usr/share/applications/"
-	cp "${srcdir}/portmaster_notifier.desktop" "${pkgdir}/usr/share/applications/"
 }

--- a/linux/PKGBUILD
+++ b/linux/PKGBUILD
@@ -33,19 +33,19 @@ prepare() {
 
 build() {
 	mkdir -p ${pkgname}-${pkgver}/data
-	chmod a+x ${srcdir}/portmaster-start
-	${srcdir}/portmaster-start --data ${pkgname}-${pkgver}/data update
+	chmod a+x "${srcdir}/portmaster-start"
+	"${srcdir}/portmaster-start" --data ${pkgname}-${pkgver}/data update
 }
 
 package() {
-	mkdir -p ${pkgdir}/var/lib/portmaster
-	mkdir -p ${pkgdir}/usr/lib/systemd/system
-	mkdir -p ${pkgdir}/usr/share/icons/hicolor/
-	mkdir -p ${pkgdir}/usr/share/applications/
-	cp ${srcdir}/portmaster.service ${pkgdir}/usr/lib/systemd/system/portmaster.service
-	cp ${srcdir}/portmaster-start ${pkgdir}/var/lib/portmaster/
-	cp -r ${srcdir}/${pkgname}-${pkgver}/data/* ${pkgdir}/var/lib/portmaster/
-	cp -r ${srcdir}/${pkgname}-${pkgver}/icons/* ${pkgdir}/usr/share/icons/hicolor/
-	cp ${srcdir}/portmaster.desktop ${pkgdir}/usr/share/applications/
-	cp ${srcdir}/portmaster_notifier.desktop ${pkgdir}/usr/share/applications/
+	install -dm 755 "${pkgdir}/var/lib/portmaster/"
+	install -dm 755 "${pkgdir}/usr/lib/systemd/system/"
+	install -dm 755 "${pkgdir}/usr/share/icons/hicolor/"
+	install -dm 755 "${pkgdir}/usr/share/applications/"
+	cp "${srcdir}/portmaster.service" "${pkgdir}/usr/lib/systemd/system/portmaster.service"
+	cp "${srcdir}/portmaster-start" "${pkgdir}/var/lib/portmaster/"
+	cp -r "${srcdir}/${pkgname}-${pkgver}/data/"* "${pkgdir}/var/lib/portmaster/"
+	cp -r "${srcdir}/${pkgname}-${pkgver}/icons/"* "${pkgdir}/usr/share/icons/hicolor/"
+	cp "${srcdir}/portmaster.desktop" "${pkgdir}/usr/share/applications/"
+	cp "${srcdir}/portmaster_notifier.desktop" "${pkgdir}/usr/share/applications/"
 }


### PR DESCRIPTION
I've done some minor tweaks to the PKGBUILD:

- Properly escape variables so spaces in paths don't break building.
- Made all the `source` definitions uniform. They used two different syntaxes and it was non-obvious that they actually did the same thing.
- Use `install` to simplify copying of files.

I have some extra feedback regarding the package in the current state of the PKGBUILD:

- You're installing the binary into /var/lib. I think you mean /usr/lib;  /var/lib is for application data, but not for applications themselves.

- AUR packages that use upstream-supplied binaries use a `-bin` suffix, so this package should be name `portmaster-bin`. `portmaster` should build from source.
