### PR TITLE
Update portmaster.service file

### DIFF
--- a/linux/debian/portmaster.service
+++ b/linux/debian/portmaster.service
@@ -15,12 +15,12 @@ LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 PrivateTmp=yes
-PIDFile=/var/lib/portmaster/core-lock.pid
+PIDFile=/opt/safing/portmaster/core-lock.pid
 Environment=LOGLEVEL=info
 Environment=PORTMASTER_ARGS=
 EnvironmentFile=-/etc/default/portmaster
 ProtectSystem=true
-#ReadWritePaths=/var/lib/portmaster
+#ReadWritePaths=/opt/safing/portmaster
 #ReadWritePaths=/run/xtables.lock
 RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
 RestrictNamespaces=yes
@@ -41,7 +41,7 @@ SystemCallArchitectures=native
 #
 #SystemCallFilter=@system-service @module
 #SystemCallErrorNumber=EPERM
-ExecStart=/var/lib/portmaster/portmaster-start --data /var/lib/portmaster core -- --log $LOGLEVEL $PORTMASTER_ARGS
+ExecStart=/opt/safing/portmaster/portmaster-start --data /opt/safing/portmaster core -- --log $LOGLEVEL $PORTMASTER_ARGS
 ExecStopPost=-/sbin/iptables -F C17
 ExecStopPost=-/sbin/iptables -t mangle -F C170
 ExecStopPost=-/sbin/iptables -t mangle -F C171


### PR DESCRIPTION
Updated the file to point to the proper links as per the updated [manual Linux](https://docs.safing.io/portmaster/install/linux) process flows.
from: `/var/lib/...` to `/opt/safing/...`

I presume this fixes failure in the Fedora rpm package installation.