### PR TITLE
Update portmaster.desktop: correct link

### DIFF
--- a/linux/portmaster.desktop
+++ b/linux/portmaster.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Portmaster
 GenericName=Application Firewall
-Exec=/var/lib/portmaster/portmaster-start app --data=/var/lib/portmaster
+Exec=/opt/safing/portmaster/portmaster-start notifier --data=/opt/safing/portmaster
 Icon=portmaster
 Terminal=false
 Type=Application


### PR DESCRIPTION
Updated the `Exec` link to: `/opt/safing/portmaster` instead of `/var/lib/postmaster