### PR TITLE
Bump windows installer version

### DIFF
--- a/windows/portmaster-installer.nsi
+++ b/windows/portmaster-installer.nsi
@@ -1,7 +1,7 @@
 Unicode true ; The Multi-Language-Part is a modified version of the MultiLanguage-NSIS-Example
 
-!define PRODUCT_VERSION "0.8.8.1"
-!define VERSION "0.8.8.1"
+!define PRODUCT_VERSION "1.0.0"
+!define VERSION "1.0.0"
 
 VIProductVersion "${PRODUCT_VERSION}"
 VIFileVersion "${VERSION}"


### PR DESCRIPTION
The latest release is `1.0.0`, however File Version and Display Version in Add/Remove Programs have not been updated to reflect this change.
![image](https://user-images.githubusercontent.com/88161975/202906623-147bcfb5-8625-4b09-948b-8a470af921c3.png)
