### PR TITLE
Fix iptables dependency for deb packages

### DIFF
--- a/linux/nfpm.yaml.template
+++ b/linux/nfpm.yaml.template
@@ -68,7 +68,8 @@ scripts:
 
 overrides:
   deb:
-    # depends: 
+    depends:
+      - iptables
     #   - libc6
     #   - libnetfilter-queue1
     recommends:


### PR DESCRIPTION
  - We use go-iptables which in turn uses the iptables binary, so we need to have a dependency for the iptables package