### PR TITLE
Fix ca-certificates dependency for deb packages

### DIFF
--- a/linux/nfpm.yaml.template
+++ b/linux/nfpm.yaml.template
@@ -70,6 +70,7 @@ overrides:
   deb:
     depends:
       - iptables
+      - ca-certificates
     #   - libc6
     #   - libnetfilter-queue1
     recommends:


### PR DESCRIPTION
This is a fix for #91. In order to install portmaster files must be downloaded via https, but this requires trusted certificates to be installed or the download will fail because the SSL cert on the server won't be trusted. To fix this we include `ca-certificates` as a dependency (this package is installed on desktop installs). This will be useful on some containers or iot installs, and to a lesser extent minimal server installs (like debootstrap installs).