### PR TITLE
Add normally available app logo icons to linux pkgs

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -12,10 +12,12 @@ nfpm.yaml: portmaster-start
 build: icons nfpm.yaml gen-scripts gen-pkgbuild
 
 icons:
-	for res in 16 32 48 96 128 ; do \
+	for res in 16 22 24 32 48 64 96 128 256 ; do \
 		mkdir -p icons/$${res}x$${res} ; \
 		convert ./portmaster_logo.png -resize "$${res}x$${res}" "icons/$${res}x$${res}/portmaster.png" ; \
 	done
+	mkdir -p icons/symbolic/apps
+	cp ./portmaster_logo.svg icons/symbolic/apps/portmaster-symbolic.svg
 
 portmaster-start:
 	curl --fail --user-agent GitHub -o portmaster-start $(STARTURL)

--- a/linux/nfpm.yaml.template
+++ b/linux/nfpm.yaml.template
@@ -48,18 +48,28 @@ contents:
 #
 # Icons
 #
-- src: icons/32x32/portmaster.png 
+- src: icons/32x32/portmaster.png
   dst: /usr/share/pixmaps/portmaster.png
-- src: icons/16x16/portmaster.png 
+- src: icons/16x16/portmaster.png
   dst: /usr/share/icons/hicolor/16x16/apps/portmaster.png
-- src: icons/32x32/portmaster.png 
+- src: icons/22x22/portmaster.png
+  dst: /usr/share/icons/hicolor/22x22/apps/portmaster.png
+- src: icons/24x24/portmaster.png
+  dst: /usr/share/icons/hicolor/24x24/apps/portmaster.png
+- src: icons/32x32/portmaster.png
   dst: /usr/share/icons/hicolor/32x32/apps/portmaster.png
-- src: icons/48x48/portmaster.png 
+- src: icons/48x48/portmaster.png
   dst: /usr/share/icons/hicolor/48x48/apps/portmaster.png
-- src: icons/96x96/portmaster.png 
+- src: icons/64x64/portmaster.png
+  dst: /usr/share/icons/hicolor/64x64/apps/portmaster.png
+- src: icons/96x96/portmaster.png
   dst: /usr/share/icons/hicolor/96x96/apps/portmaster.png
 - src: icons/128x128/portmaster.png
   dst: /usr/share/icons/hicolor/128x128/apps/portmaster.png
+- src: icons/256x256/portmaster.png
+  dst: /usr/share/icons/hicolor/256x256/apps/portmaster.png
+- src: icons/symbolic/apps/portmaster-symbolic.svg
+  dst: /usr/share/icons/hicolor/symbolic/apps/portmaster-symbolic.svg
 scripts:
   preinstall: ./scripts/preinstall.sh
   postinstall: ./scripts/postinstall.sh

--- a/linux/portmaster_logo.svg
+++ b/linux/portmaster_logo.svg
@@ -1,0 +1,8 @@
+<svg class="h-6 w-auto mr-4" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <g data-name="Main" fill-rule="evenodd">
+    <path fill="#fff" d="M176.11 36.73l-5-8.61a41.53 41.53 0 00-14.73 57.22l8.55-5.12a31.58 31.58 0 0111.19-43.49z" transform="translate(-127.99 .01)" style="isolation:isolate" opacity=".8"></path>
+    <path fill="#fff" d="M222.36 72.63a31.55 31.55 0 01-45 19.35l-4.62 8.84a41.54 41.54 0 0059.17-25.46z" transform="translate(-127.99 .01)" style="isolation:isolate" opacity=".8"></path>
+    <path fill="#fff" d="M197 83a19.66 19.66 0 01-19.25-32.57l-4.5-4.27A25.87 25.87 0 00198.59 89z" transform="translate(-127.99 .01)" style="isolation:isolate" opacity=".6"></path>
+    <path fill="#fff" d="M192 112.64A48.64 48.64 0 11240.64 64 48.64 48.64 0 01192 112.64zM256 64a64 64 0 10-64 64 64 64 0 0064-64z" transform="translate(-127.99 .1)"></path>
+  </g>
+</svg>


### PR DESCRIPTION
  - fix for issue #93
  - adds normally availble icon sizes that are missing
  - adds SVG icon