### PR TITLE
Add low memory protection

### DIFF
--- a/linux/portmaster.service
+++ b/linux/portmaster.service
@@ -14,6 +14,7 @@ Restart=on-failure
 RestartSec=10
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
+MemoryLow=2G
 NoNewPrivileges=yes
 PrivateTmp=yes
 PIDFile=/opt/safing/portmaster/core-lock.pid


### PR DESCRIPTION
If the system is under memory stress, memory allocation latency spikes which disrupts proper operation of portmaster, resulting in DNS timeouts. While the memory pressure persists, portmaster never recovers.

Fix it by adding a low memory protection to the systemd service. From experiments, 2 GB is enough to stop the system from swapping important memory of portmaster and reduce cache thrashing. A lower value like 1 GB might work, too. The resident size of portmaster peaks at around 530 MB for me but this value as low protection is not enough, we need to protect some IO cache memory, too.

After applying to the running service, DNS operation almost instantly recovers.